### PR TITLE
 feat(dpdata): add shuffle command to DpdataTool

### DIFF
--- a/ai2_kit/tool/dpdata.py
+++ b/ai2_kit/tool/dpdata.py
@@ -11,6 +11,7 @@ from ai2_kit.core.log import get_logger
 
 import os
 import glob
+import random
 
 from typing import Optional
 from dpdata.data_type import Axis, DataType
@@ -84,6 +85,17 @@ class DpdataTool:
         """
         s = slice_from_str(expr)
         self._systems = self._systems[s]
+        return self
+
+    def shuffle(self, seed=None):
+        """
+        shuffle systems in random order
+
+        :param seed: seed for random shuffle, set it to get reproducible result
+        """
+        if seed is not None:
+            random.seed(seed)
+        random.shuffle(self._systems)
         return self
 
     def sample(self, size: int, method: SAMPLE_METHOD = "even", **kwargs):

--- a/doc/manual/dpdata.md
+++ b/doc/manual/dpdata.md
@@ -24,6 +24,7 @@ This toolkit include the following commands:
 | filter     | Use lambda expression to filter dataset by system data.                                                                     | See in `Example`                                                                               |                                             |
 | set_fparam | add `fparam` to dataset, can be float or list of float                                                                      | See in `Example`                                                                               |                                             |
 | slice      | use slice expression to process systems                                                                                     | see in `Example`                                                                               |                                             |
+| shuffle    | shuffle systems in random order, use `--seed` to get reproducible result                                                    | see in `Example`                                                                               |                                             |
 | sample     | sample data by different methods, current supported method are `even` and `random`                                          | see in `Example`                                                                               |                                             |
 | eval       | use `deepmd DeepPot` to (re)label loaded data                                                                               | see in `Example`                                                                               |                                             |
 | to_ase     | convert dpdata format to ase format and use [ase tool](./ase.md) to process                                                 | see in `Example`                                                                               |                                             |
@@ -51,6 +52,9 @@ ai2-kit tool dpdata read dp-h2o --nolabel - eval dp-frozen.pb - write new-dp-h2o
 
 # Drop the first 10 frames and then sample 10 frames use random method, and save it as xyz format
 ai2-kit tool dpdata read dp-h2o --fmt deepmd/npy - slice 10: - sample 10 --method random - to_ase - write h2o.xyz
+
+# Shuffle the dataset with a fixed seed and take the first 100 frames as training set
+ai2-kit tool dpdata read dp-h2o --fmt deepmd/npy - shuffle --seed 42 - slice :100 - write ./train-set
 
 # Convert dpdata to ase format and write VASP POSCAR files
 ai2-kit tool dpdata read dp-h2o --fmt deepmd/npy - to_ase - write_frames "./vasp-{i-04d}/POSCAR" --format vasp 


### PR DESCRIPTION
## Summary

Add a `shuffle` command to the `dpdata` tool that randomizes the order of loaded systems, with an optional `--seed` for reproducibility.

## Motivation

When splitting datasets into train/validation/test sets (e.g. via `slice` after `shuffle`), users currently have no built-in way to randomize system ordering. This forces workarounds or non-reproducible splits. A dedicated `shuffle` command makes the workflow first-class and seedable.

## Changes

- **`ai2_kit/tool/dpdata.py`**
  - `DpdataTool.shuffle(self, seed=None)` — performs an in-place `random.shuffle` of `self._systems`; sets `random.seed` when a seed is given for reproducible output. Returns `self` to stay chainable.
  - Added `import random`.
- **`doc/manual/dpdata.md`**
  - Added `shuffle` row to the command table.
  - Added a usage example chaining `shuffle --seed 42` with `slice` to build a training set.

Since the CLI is driven by Python Fire, the new method is automatically exposed as `ai2-kit tool dpdata ... - shuffle --seed N - ...` — no extra registration is required.

## Usage

```bash
# Reproducible shuffle, then take first 100 systems as training set
ai2-kit tool dpdata read dp-h2o --fmt deepmd/npy - shuffle --seed 42 - slice :100 - write ./train-set
```
